### PR TITLE
Add FieldName to Hive2 primitive object inspectors

### DIFF
--- a/serde/build.gradle
+++ b/serde/build.gradle
@@ -18,6 +18,7 @@ group = "com.amazon.ion"
 
 apply plugin: 'java-library'
 apply plugin: "maven-publish"
+apply plugin: "maven"
 apply plugin: "signing"
 
 jar.baseName = 'ion-hive2-serde'

--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/EncodingConfig.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/EncodingConfig.java
@@ -32,7 +32,7 @@ class EncodingConfig {
      * @param configuration raw configuration.
      */
     EncodingConfig(final RawConfiguration configuration) {
-        encoding = IonEncoding.valueOf(configuration.getOrDefault(ENCODING_KEY, DEFAULT_ENCODING));
+        encoding = IonEncoding.fromConfigValue(configuration.getOrDefault(ENCODING_KEY, DEFAULT_ENCODING));
     }
 
     /**

--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/IonEncoding.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/IonEncoding.java
@@ -27,5 +27,14 @@ public enum IonEncoding {
     /**
      * Ion text.
      */
-    TEXT
+    TEXT;
+
+    /**
+     * Case insensitive function to retrieve the encoding from a user specified value.
+     * @param encodingValue - String with the encoding value (usually passed in ion.encoding)
+     * @return Enum value corresponding to the passed in string
+     */
+    public static IonEncoding fromConfigValue(final String encodingValue) {
+        return IonEncoding.valueOf(encodingValue.toUpperCase());
+    }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/factories/IonObjectInspectorFactory.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/factories/IonObjectInspectorFactory.java
@@ -35,6 +35,17 @@ import com.amazon.ionhiveserde.objectinspectors.IonTimestampToDateObjectInspecto
 import com.amazon.ionhiveserde.objectinspectors.IonTimestampToTimestampObjectInspector;
 import com.amazon.ionhiveserde.objectinspectors.IonUnionObjectInspector;
 import com.amazon.ionhiveserde.objectinspectors.IonValueToStringObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToBigIntObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToBooleanObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToDateObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToDecimalObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToDoubleObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToFloatObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToIntObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToSmallIntObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToStringObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToTimestampObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.map.IonFieldNameToTinyIntObjectInspector;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,6 +101,38 @@ public class IonObjectInspectorFactory {
         new IonTimestampToTimestampObjectInspector();
     private static final IonValueToStringObjectInspector ION_VALUE_TO_STRING_OBJECT_INSPECTOR =
             new IonValueToStringObjectInspector();
+
+    // Map Key Object Inspectors
+    private static final IonFieldNameToBooleanObjectInspector FIELD_NAME_TO_BOOLEAN_OBJECT_INSPECTOR =
+            new IonFieldNameToBooleanObjectInspector();
+    private static final IonFieldNameToBigIntObjectInspector FIELD_NAME_TO_BIGINT_OBJECT_INSPECTOR =
+            new IonFieldNameToBigIntObjectInspector();
+    private static final IonFieldNameToDateObjectInspector FIELD_NAME_TO_DATE_OBJECT_INSPECTOR =
+            new IonFieldNameToDateObjectInspector();
+    private static final IonFieldNameToDecimalObjectInspector FIELD_NAME_TO_DECIMAL_OBJECT_INSPECTOR =
+            new IonFieldNameToDecimalObjectInspector();
+    private static final IonFieldNameToDoubleObjectInspector FIELD_NAME_TO_DOUBLE_OBJECT_INSPECTOR =
+            new IonFieldNameToDoubleObjectInspector();
+    private static final IonFieldNameToFloatObjectInspector FIELD_NAME_TO_FLOAT_FAIL_OBJECT_INSPECTOR =
+            new IonFieldNameToFloatObjectInspector(true);
+    private static final IonFieldNameToFloatObjectInspector FIELD_NAME_TO_FLOAT_OBJECT_INSPECTOR =
+            new IonFieldNameToFloatObjectInspector(false);
+    private static final IonFieldNameToIntObjectInspector FIELD_NAME_TO_INT_FAIL_OBJECT_INSPECTOR =
+            new IonFieldNameToIntObjectInspector(true);
+    private static final IonFieldNameToIntObjectInspector FIELD_NAME_TO_INT_OBJECT_INSPECTOR =
+            new IonFieldNameToIntObjectInspector(false);
+    private static final IonFieldNameToSmallIntObjectInspector FIELD_NAME_TO_SMALLINT_FAIL_OBJECT_INSPECTOR =
+            new IonFieldNameToSmallIntObjectInspector(true);
+    private static final IonFieldNameToSmallIntObjectInspector FIELD_NAME_TO_SMALLINT_OBJECT_INSPECTOR =
+            new IonFieldNameToSmallIntObjectInspector(false);
+    private static final IonFieldNameToStringObjectInspector FIELD_NAME_TO_STRING_OBJECT_INSPECTOR =
+            new IonFieldNameToStringObjectInspector();
+    private static final IonFieldNameToTimestampObjectInspector FIELD_NAME_TO_TIMESTAMP_OBJECT_INSPECTOR =
+            new IonFieldNameToTimestampObjectInspector();
+    private static final IonFieldNameToTinyIntObjectInspector FIELD_NAME_TO_TINYINT_FAIL_OBJECT_INSPECTOR =
+            new IonFieldNameToTinyIntObjectInspector(true);
+    private static final IonFieldNameToTinyIntObjectInspector FIELD_NAME_TO_TINYINT_OBJECT_INSPECTOR =
+            new IonFieldNameToTinyIntObjectInspector(false);
 
     /**
      * Creates an object inspector for the table correctly configured.
@@ -230,14 +273,17 @@ public class IonObjectInspectorFactory {
                 break;
             case MAP:
                 final MapTypeInfo mapTypeInfo = (MapTypeInfo) typeInfo;
-
+                final ObjectInspector keyObjectInspector = getMapKeyObjectInspector(
+                        mapTypeInfo,
+                        fieldName,
+                        serDeProperties);
                 // FIXME validate key must be string
                 final ObjectInspector valueObjectInspector = objectInspectorForField(
                     mapTypeInfo.getMapValueTypeInfo(),
                     fieldName,
                     serDeProperties);
 
-                objectInspector = new IonStructToMapObjectInspector(valueObjectInspector);
+                objectInspector = new IonStructToMapObjectInspector(keyObjectInspector, valueObjectInspector);
                 break;
 
             case LIST:
@@ -261,5 +307,67 @@ public class IonObjectInspectorFactory {
         }
 
         return objectInspector;
+    }
+
+    private static ObjectInspector getMapKeyObjectInspector(
+            final MapTypeInfo typeInfo,
+            final String fieldName,
+            final SerDeProperties serDeProperties) {
+        ObjectInspector objectInspector = null;
+        final boolean failOnOverflow = serDeProperties.failOnOverflowFor(fieldName);
+
+        switch (typeInfo.getMapKeyTypeInfo().getCategory()) {
+            case PRIMITIVE:
+                final PrimitiveTypeInfo mapKeyPrimitiveTypeInfo = (PrimitiveTypeInfo) typeInfo.getMapKeyTypeInfo();
+                switch (mapKeyPrimitiveTypeInfo.getPrimitiveCategory()) {
+                    case BOOLEAN:
+                        objectInspector = FIELD_NAME_TO_BOOLEAN_OBJECT_INSPECTOR;
+                        break;
+                    case BYTE:
+                        objectInspector = failOnOverflow
+                                ? FIELD_NAME_TO_TINYINT_FAIL_OBJECT_INSPECTOR
+                                : FIELD_NAME_TO_TINYINT_OBJECT_INSPECTOR;
+                        break;
+                    case DATE:
+                        objectInspector = FIELD_NAME_TO_DATE_OBJECT_INSPECTOR;
+                        break;
+                    case DECIMAL:
+                        objectInspector = FIELD_NAME_TO_DECIMAL_OBJECT_INSPECTOR;
+                        break;
+                    case DOUBLE:
+                        objectInspector = FIELD_NAME_TO_DOUBLE_OBJECT_INSPECTOR;
+                        break;
+                    case FLOAT:
+                        objectInspector = failOnOverflow
+                                ? FIELD_NAME_TO_FLOAT_FAIL_OBJECT_INSPECTOR
+                                : FIELD_NAME_TO_FLOAT_OBJECT_INSPECTOR;
+                        break;
+                    case INT:
+                        objectInspector = failOnOverflow
+                                ? FIELD_NAME_TO_INT_FAIL_OBJECT_INSPECTOR
+                                : FIELD_NAME_TO_INT_OBJECT_INSPECTOR;
+                        break;
+                    case LONG:
+                        objectInspector = FIELD_NAME_TO_BIGINT_OBJECT_INSPECTOR;
+                        break;
+                    case SHORT:
+                        objectInspector = failOnOverflow
+                                ? FIELD_NAME_TO_SMALLINT_FAIL_OBJECT_INSPECTOR
+                                : FIELD_NAME_TO_SMALLINT_OBJECT_INSPECTOR;
+                        break;
+                    case TIMESTAMP:
+                        objectInspector = FIELD_NAME_TO_TIMESTAMP_OBJECT_INSPECTOR;
+                        break;
+                    case VARCHAR:
+                    case CHAR:
+                    case STRING:
+                        objectInspector = FIELD_NAME_TO_STRING_OBJECT_INSPECTOR;
+                        break;
+                }
+                break;
+            default:
+                throw new UnsupportedOperationException("Unknown primitive category");
+        }
+        return  objectInspector;
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/AbstractFieldNameObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/AbstractFieldNameObjectInspector.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.AbstractIonPrimitiveJavaObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+
+/**
+ * Base class for primitive object inspectors that need to handle overflow detection.
+ *
+ * @param <O> Primitive type.
+ */
+abstract class AbstractFieldNameObjectInspector<O> extends
+        AbstractIonPrimitiveJavaObjectInspector {
+
+    private final boolean failOnOverflow;
+
+    /**
+     * Constructor.
+     *
+     * @param typeInfo type info for this object inspector.
+     */
+    AbstractFieldNameObjectInspector(final PrimitiveTypeInfo typeInfo) {
+        this(typeInfo, false);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param typeInfo type info for this object inspector.
+     * @param failOnOverflow if should fail when detecting an overflow.
+     */
+    AbstractFieldNameObjectInspector(final PrimitiveTypeInfo typeInfo,
+                                                 final boolean failOnOverflow) {
+        super(typeInfo);
+        this.failOnOverflow = failOnOverflow;
+    }
+
+    /**
+     * Gets the primitive Java representation of an Ion value detecting and handling overflows.
+     *
+     * @param fieldName Value to read as a Java primitive.
+     * @return Java primitive representation.
+     */
+    final O getPrimitiveJavaObjectFromFieldName(final Object fieldName) {
+        final String fieldNameAsString;
+        if (fieldName instanceof String) {
+            fieldNameAsString = (String) fieldName;
+        } else {
+            fieldNameAsString = fieldName.toString();
+        }
+        if (failOnOverflow) {
+            validateSize(fieldNameAsString);
+        }
+
+        return getValidatedPrimitiveJavaObject(fieldNameAsString);
+    }
+
+    /**
+     * Gets the primitive Java representation of an Ion value that has passed overflow validation.
+     *
+     * @param fieldName Value to read as a Java primitive.
+     * @return Java primitive representation.
+     */
+    protected abstract O getValidatedPrimitiveJavaObject(final String fieldName);
+
+    /**
+     * Validates if an ion value will overflow when converted to java primitive.
+     *
+     * @param fieldName Ion value to be validated.
+     * @throws IllegalArgumentException when detecting an overflow.
+     * @throws UnsupportedOperationException if a function has not overridden validateSize and failOnOverflow is true.
+     */
+    protected void validateSize(final String fieldName) {
+        if (failOnOverflow) {
+            throw new UnsupportedOperationException(
+                    String.format("Type %s is marked as fail on overflow, but has not implemented validation",
+                            this.getClass().getSimpleName()));
+        }
+    }
+
+    /**
+     * Returns a java primitive object from a field name
+     * @param o - Object o that contains a string version of the field name
+     * @return Java primitive object
+     */
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.LongWritable;
+
+public class IonFieldNameToBigIntObjectInspector
+        extends AbstractFieldNameObjectInspector<Long>
+        implements LongObjectInspector {
+
+    public IonFieldNameToBigIntObjectInspector() {
+        super(TypeInfoFactory.longTypeInfo);
+    }
+
+    @Override
+    public long get(final Object o) {
+        return (long) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new LongWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Long getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return IonPrimitiveReader.longValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.BooleanWritable;
+
+public class IonFieldNameToBooleanObjectInspector
+        extends AbstractFieldNameObjectInspector<Boolean>
+        implements BooleanObjectInspector {
+
+    public IonFieldNameToBooleanObjectInspector() {
+        super(TypeInfoFactory.booleanTypeInfo);
+    }
+
+    @Override
+    public boolean get(final Object o) {
+        return (boolean) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new BooleanWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Boolean getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return IonPrimitiveReader.booleanValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ion.Timestamp;
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import java.sql.Date;
+import java.time.LocalDate;
+
+import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+public class IonFieldNameToDateObjectInspector
+        extends AbstractFieldNameObjectInspector<Date>
+        implements DateObjectInspector {
+
+    public IonFieldNameToDateObjectInspector() {
+        super(TypeInfoFactory.dateTypeInfo);
+    }
+
+    @Override
+    public Date getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o);
+    }
+
+    @Override
+    public DateWritable getPrimitiveWritableObject(final Object o) {
+        return new DateWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Date getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            Timestamp ionTimestamp = IonPrimitiveReader.timestampValue(fieldName);
+            return Date.valueOf(LocalDate.of(ionTimestamp.getYear(), ionTimestamp.getMonth(), ionTimestamp.getDay()));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+public class IonFieldNameToDecimalObjectInspector
+        extends AbstractFieldNameObjectInspector<HiveDecimal>
+        implements HiveDecimalObjectInspector {
+
+    public IonFieldNameToDecimalObjectInspector() {
+        super(TypeInfoFactory.decimalTypeInfo);
+    }
+
+    @Override
+    public HiveDecimal getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o);
+    }
+
+    @Override
+    public HiveDecimalWritable getPrimitiveWritableObject(final Object o) {
+        return new HiveDecimalWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected HiveDecimal getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return HiveDecimal.create(IonPrimitiveReader.decimalValue(fieldName));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.DoubleWritable;
+
+public class IonFieldNameToDoubleObjectInspector
+        extends AbstractFieldNameObjectInspector<Double>
+        implements DoubleObjectInspector {
+
+    public IonFieldNameToDoubleObjectInspector() {
+        super(TypeInfoFactory.doubleTypeInfo);
+    }
+
+    @Override
+    public double get(final Object o) {
+        return (double) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o);
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new DoubleWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Double getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return IonPrimitiveReader.doubleValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.FloatWritable;
+
+public class IonFieldNameToFloatObjectInspector
+        extends AbstractFieldNameObjectInspector<Float>
+        implements FloatObjectInspector {
+
+    public IonFieldNameToFloatObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.floatTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    public float get(final Object o) {
+        return (float) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new FloatWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Float getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return IonPrimitiveReader.floatValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        Double doubleValue = IonPrimitiveReader.doubleValue(fieldName);
+
+        if (Double.compare(doubleValue.floatValue(), doubleValue) != 0) {
+            throw new IllegalArgumentException(
+                    "insufficient precision for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.IntWritable;
+
+public class IonFieldNameToIntObjectInspector
+        extends AbstractFieldNameObjectInspector<Integer>
+        implements IntObjectInspector {
+
+    public IonFieldNameToIntObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.intTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    public int get(final Object o) {
+        return (int) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new IntWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Integer getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return IonPrimitiveReader.intValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        long value = IonPrimitiveReader.longValue(fieldName);
+
+        if (!validRange(value)) {
+            throw new IllegalArgumentException(
+                    "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    private boolean validRange(final long value) {
+        // runs after checking that fits in a Java int
+        return Integer.MIN_VALUE <= value && value <= Integer.MAX_VALUE;
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ShortObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.ShortWritable;
+
+public class IonFieldNameToSmallIntObjectInspector
+        extends AbstractFieldNameObjectInspector<Short>
+        implements ShortObjectInspector {
+
+    public IonFieldNameToSmallIntObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.shortTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    public short get(final Object o) {
+        return (short) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new ShortWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Short getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return IonPrimitiveReader.shortValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        long value = IonPrimitiveReader.longValue(fieldName);
+
+        if (!validRange(value)) {
+            throw new IllegalArgumentException(
+                    "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    private boolean validRange(final long value) {
+        // runs after checking that fits in a Java short
+        return Short.MIN_VALUE <= value && value <= Short.MAX_VALUE;
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.Text;
+
+public class IonFieldNameToStringObjectInspector
+        extends AbstractFieldNameObjectInspector<String>
+        implements StringObjectInspector {
+
+    public IonFieldNameToStringObjectInspector() {
+        super(TypeInfoFactory.stringTypeInfo);
+    }
+
+    @Override
+    public Text getPrimitiveWritableObject(final Object o) {
+        return new Text(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    public String getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o);
+    }
+
+    @Override
+    protected String getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return IonPrimitiveReader.stringValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTimestampObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTimestampObjectInspector.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import java.sql.Timestamp;
+
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+public class IonFieldNameToTimestampObjectInspector
+        extends AbstractFieldNameObjectInspector<Timestamp>
+        implements TimestampObjectInspector {
+
+    public IonFieldNameToTimestampObjectInspector() {
+        super(TypeInfoFactory.timestampTypeInfo);
+    }
+
+    @Override
+    public Timestamp getPrimitiveJavaObject(final Object o) {
+        if (o instanceof Timestamp) {
+            return (Timestamp) o;
+        }
+        return getPrimitiveJavaObjectFromFieldName(o);
+    }
+
+    @Override
+    public TimestampWritable getPrimitiveWritableObject(final Object o) {
+        if (o instanceof Timestamp) {
+            return new TimestampWritable((Timestamp) o);
+        }
+        return new TimestampWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Timestamp getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return new Timestamp(IonPrimitiveReader.timestampValue(fieldName).getMillis());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.ShortWritable;
+
+public class IonFieldNameToTinyIntObjectInspector
+        extends AbstractFieldNameObjectInspector<Byte>
+        implements ByteObjectInspector {
+
+    public IonFieldNameToTinyIntObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.byteTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    public byte get(final Object o) {
+        return (byte) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new ShortWritable(getPrimitiveJavaObjectFromFieldName(o));
+    }
+
+    @Override
+    protected Byte getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return IonPrimitiveReader.byteValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        long value = IonPrimitiveReader.longValue(fieldName);
+
+        if (!validRange(value)) {
+            throw new IllegalArgumentException(
+                    "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    private boolean validRange(final long value) {
+        // runs after checking that fits in a Java byte
+        return Byte.MIN_VALUE <= value && value <= Byte.MAX_VALUE;
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/utils/IonPrimitiveReader.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/utils/IonPrimitiveReader.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.utils;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonType;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.system.IonReaderBuilder;
+import com.google.common.collect.ImmutableSet;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Set;
+
+public class IonPrimitiveReader {
+
+    private static final IonReaderBuilder READER_BUILDER = IonReaderBuilder.standard().immutable();
+
+    // Restricted to boolean ion types
+    /**
+     * Convert a string containing a single serialized IonValue to a boolean.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return boolean value.
+     */
+    public static boolean booleanValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.BOOLEAN).booleanValue();
+    }
+
+    // Restricted to numeric ion types
+    /**
+     * Convert a string containing a single serialized IonValue to a byte.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return byte value.
+     */
+    public static byte byteValue(final String ionPrimitive) {
+        return (byte) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
+    }
+
+    /**
+     * Convert a string containing a single serialized IonValue to a BigDecimal.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return BigDecimal value.
+     */
+    public static BigDecimal decimalValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.NUMERIC).bigDecimalValue();
+    }
+
+    /**
+     * Convert a string containing a single serialized IonValue to a double.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return double value.
+     */
+    public static double doubleValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.NUMERIC).doubleValue();
+    }
+
+    /**
+     * Convert a string containing a single serialized IonValue to a float.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return float value.
+     */
+    public static float floatValue(final String ionPrimitive) {
+        return (float) buildSingleReader(ionPrimitive, CastType.FLOAT).doubleValue();
+    }
+
+    /**
+     * Convert a string containing a single serialized IonValue to an int.
+     * @param ionPrimitive - - String with serialized Ion value.
+     * @return int value.
+     */
+    public static int intValue(final String ionPrimitive) {
+        return (int) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
+    }
+
+    /**
+     * Convert a string containing a single serialized IonValue to a long.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return long value.
+     */
+    public static long longValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
+    }
+
+    /**
+     * Convert a string containing a single serialized IonValue to a short.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return short value.
+     */
+    public static short shortValue(final String ionPrimitive) {
+        return (short) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
+    }
+
+    // Restricted to temporal ion types
+
+    /**
+     * Convert a string containing a single serialized IonValue to an Ion timestamp.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return Ion timestamp value.
+     */
+    public static Timestamp timestampValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.TEMPORAL).timestampValue();
+    }
+
+    // No restrictions on ion type
+    /**
+     * Reads a single string containing a serialized IonValue as a string.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return String value containing text representation of an IonValue.
+     */
+    public static String stringValue(final String ionPrimitive) {
+        IonReader reader = READER_BUILDER.build(ionPrimitive);
+        IonType type = reader.next();
+        validateReader(ionPrimitive, type, CastType.STRING);
+        return toStringValue(reader, type, ionPrimitive);
+    }
+
+    private static IonReader buildSingleReader(final String ionPrimitive, final CastType targetType) {
+        IonReader reader = READER_BUILDER.build(ionPrimitive);
+        IonType type = reader.next();
+        validateReader(ionPrimitive, type, targetType);
+        return reader;
+    }
+
+    private static void validateReader(final String ionPrimitive, final IonType type, final CastType targetType) {
+
+        if (!targetType.canCast(type)) {
+            throw new IllegalArgumentException(
+                    String.format("Unable to cast value %s of type %s as %s type.",
+                            ionPrimitive,
+                            type.name(),
+                            targetType.toString().toLowerCase()));
+        }
+    }
+
+    private static String toStringValue(final IonReader reader, final IonType type, final String ionPrimitive) {
+        String stringValue;
+        switch (type) {
+            case BOOL:
+                stringValue = String.valueOf(reader.booleanValue());
+                break;
+            case DECIMAL:
+                stringValue = reader.decimalValue().toString();
+                break;
+            case FLOAT:
+                stringValue = String.valueOf(reader.doubleValue());
+                break;
+            case INT:
+                stringValue = String.valueOf(reader.intValue());
+                break;
+            case TIMESTAMP:
+                stringValue = reader.timestampValue().toString();
+                break;
+            default:
+                stringValue = reader.stringValue();
+        }
+        return stringValue;
+    }
+
+    private enum CastType {
+        BOOLEAN,
+        FLOAT,
+        NUMERIC,
+        STRING,
+        TEMPORAL;
+
+        private static Set<IonType> NUMERIC_TYPE = ImmutableSet.of(IonType.INT, IonType.DECIMAL, IonType.FLOAT);
+        private static Set<IonType> FLOAT_TYPE = ImmutableSet.of(IonType.DECIMAL, IonType.FLOAT);
+
+        public boolean canCast(final IonType type) {
+            switch (this) {
+                case BOOLEAN:
+                    return type == IonType.BOOL;
+                case FLOAT:
+                    return FLOAT_TYPE.contains(type);
+                case NUMERIC:
+                    return NUMERIC_TYPE.contains(type);
+                case STRING:
+                    return true;
+                case TEMPORAL:
+                    return type == IonType.TIMESTAMP;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -18,92 +18,315 @@ package com.amazon.ionhiveserde.objectinspectors
 import com.amazon.ion.IonStruct
 import com.amazon.ionhiveserde.ION
 import com.amazon.ionhiveserde.ionNull
+import com.amazon.ionhiveserde.objectinspectors.map.*
+import org.apache.hadoop.hive.common.type.HiveDecimal
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.MAP
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE
 import org.junit.Test
+import java.sql.Date
+import java.sql.Timestamp
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.fail
 
 class IonStructToMapObjectInspectorTest {
-    private val valueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val subject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(valueElementInspector)
+    private val elementInspector = IonIntToIntObjectInspector(true)
+
+    private val stringIntSubject = IonStructToMapObjectInspector(IonFieldNameToStringObjectInspector(), elementInspector)
+    private val intIntSubject = IonStructToMapObjectInspector(IonFieldNameToIntObjectInspector(true), elementInspector)
+    private val intIntSubjectOverflow = IonStructToMapObjectInspector(IonFieldNameToIntObjectInspector(false), elementInspector)
+    private val bigintIntSubject = IonStructToMapObjectInspector(IonFieldNameToBigIntObjectInspector(), elementInspector)
+    private val smallintIntSubject = IonStructToMapObjectInspector(IonFieldNameToSmallIntObjectInspector(true), elementInspector)
+    private val tinyintIntSubject = IonStructToMapObjectInspector(IonFieldNameToTinyIntObjectInspector(true), elementInspector)
+    private val floatIntSubject = IonStructToMapObjectInspector(IonFieldNameToFloatObjectInspector(true), elementInspector)
+    private val doubleIntSubject = IonStructToMapObjectInspector(IonFieldNameToDoubleObjectInspector(), elementInspector)
+    private val booleanIntSubject = IonStructToMapObjectInspector(IonFieldNameToBooleanObjectInspector(), elementInspector)
+    private val decimalIntSubject = IonStructToMapObjectInspector(IonFieldNameToDecimalObjectInspector(), elementInspector)
+    private val dateIntSubject = IonStructToMapObjectInspector(IonFieldNameToDateObjectInspector(), elementInspector)
+    private val timestampIntSubject = IonStructToMapObjectInspector(IonFieldNameToTimestampObjectInspector(), elementInspector)
+
+
+    private val testBigints = listOf<Long>(1L, 2L, 3L)
+    private val testBooleans = listOf<Boolean>(true, false)
+    private val testDates = listOf<Date>(
+            Date.valueOf("1991-1-1"),
+            Date.valueOf("1992-2-3"))
+    private val testDecimals = listOf<HiveDecimal>(HiveDecimal.create(1), HiveDecimal.create(2))
+    private val testDoubles = listOf<Double>(2.0, 4.0, 6.0)
+    private val testFloats = listOf<Float>(2f, 4f, 8f)
+    private val testInts = listOf<Int>(1, 2, 3)
+    private val testSmallints = listOf<Short>(1, 2, 3)
+    private val testStrings = listOf<String>("a", "b", "c")
+    private val testTimestamps = listOf<Timestamp>(
+            Timestamp.valueOf("2014-10-14 12:34:56.789"),
+            Timestamp.valueOf("2015-10-16 12:34:56.789"))
+    private val testTinyints = listOf<Byte>(1, 2, 3)
+
 
     @Test
     fun getMapKeyObjectInspector() {
-        assertEquals(PrimitiveObjectInspectorFactory.javaStringObjectInspector, subject.mapKeyObjectInspector)
+        assertEquals(stringIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(intIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(intIntSubjectOverflow.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(bigintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(smallintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(tinyintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(floatIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(doubleIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(booleanIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(decimalIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(dateIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(timestampIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
     }
 
     @Test
     fun getMapValueObjectInspector() {
-        assertEquals(valueElementInspector, subject.mapValueObjectInspector)
+        assertEquals(elementInspector, stringIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, intIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, intIntSubjectOverflow.mapValueObjectInspector)
+        assertEquals(elementInspector, bigintIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, smallintIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, tinyintIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, floatIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, doubleIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, booleanIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, decimalIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, dateIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, timestampIntSubject.mapValueObjectInspector)
     }
 
     @Test
     fun getMapValueElement() {
-        val struct = makeStruct()
+        val structs = makeStructs()
+        testGetMapValueElement(structs[0], stringIntSubject, testStrings)
+        testGetMapValueElement(structs[1], intIntSubject, testInts.map { it.toString() })
+        testGetMapValueElement(structs[1], intIntSubjectOverflow, testInts.map { it.toString() })
+        testGetMapValueElement(structs[2], bigintIntSubject, testBigints.map { it.toString() })
+        testGetMapValueElement(structs[3], smallintIntSubject, testSmallints.map { it.toString() })
+        testGetMapValueElement(structs[4], tinyintIntSubject, testTinyints.map { it.toString() })
+        testGetMapValueElement(structs[5], floatIntSubject, testFloats.map { it.toString() })
+        testGetMapValueElement(structs[6], doubleIntSubject, testDoubles.map { it.toString() })
+        testGetMapValueElement(structs[7], booleanIntSubject, testBooleans.map { it.toString() })
+        testGetMapValueElement(structs[8], decimalIntSubject, testDecimals.map { it.toString() })
+        testGetMapValueElement(structs[9], dateIntSubject, testDates.map { it.toString() })
+        testGetMapValueElement(structs[10], timestampIntSubject, testTimestamps.map { getTsKey(it) })
+    }
 
-        assertEquals(ION.newInt(1), subject.getMapValueElement(struct, ION.newSymbol("a")))
-        assertEquals(ION.newInt(2), subject.getMapValueElement(struct, ION.newSymbol("b")))
-        assertEquals(ION.newInt(3), subject.getMapValueElement(struct, ION.newSymbol("c")))
-        assertNull(subject.getMapValueElement(struct, ION.newSymbol("d")))
+    private fun testGetMapValueElement(struct: IonStruct, subject : IonStructToMapObjectInspector, keys: List<String>) {
+        var structVal = 1
+        keys.forEach{assertEquals(ION.newInt(structVal++), subject.getMapValueElement(struct, ION.newSymbol(it)))}
+        assertNull(subject.getMapValueElement(struct, ION.newSymbol("4")))
     }
 
     @Test
     fun getMapValueElementForNullData() {
-        assertNull(subject.getMapValueElement(null, ION.newSymbol("a")))
-        assertNull(subject.getMapValueElement(ionNull, ION.newSymbol("a")))
+        assertNull(stringIntSubject.getMapValueElement(null, ION.newSymbol("a")))
+        assertNull(stringIntSubject.getMapValueElement(ionNull, ION.newSymbol("a")))
+
+        assertNull(intIntSubject.getMapValueElement(null, ION.newSymbol("1")))
+        assertNull(intIntSubject.getMapValueElement(ionNull, ION.newSymbol("1")))
+
+        assertNull(bigintIntSubject.getMapValueElement(null, ION.newSymbol("1")))
+        assertNull(bigintIntSubject.getMapValueElement(ionNull, ION.newSymbol("1")))
+
+        assertNull(smallintIntSubject.getMapValueElement(null, ION.newSymbol("1")))
+        assertNull(smallintIntSubject.getMapValueElement(ionNull, ION.newSymbol("1")))
+
+        assertNull(tinyintIntSubject.getMapValueElement(null, ION.newSymbol("1")))
+        assertNull(tinyintIntSubject.getMapValueElement(ionNull, ION.newSymbol("1")))
+
+        val floatVal = 2f;
+        assertNull(floatIntSubject.getMapValueElement(null, ION.newSymbol(floatVal.toString())))
+        assertNull(floatIntSubject.getMapValueElement(ionNull, ION.newSymbol(floatVal.toString())))
+
+        val doubleVal = 2.0;
+        assertNull(doubleIntSubject.getMapValueElement(null, ION.newSymbol(doubleVal.toString())))
+        assertNull(doubleIntSubject.getMapValueElement(ionNull, ION.newSymbol(doubleVal.toString())))
+
+        // No boolean check here because both true and false are already used
+
+        val decimalVal = HiveDecimal.create(3)
+        assertNull(decimalIntSubject.getMapValueElement(null, ION.newSymbol(decimalVal.toString())))
+        assertNull(decimalIntSubject.getMapValueElement(ionNull, ION.newSymbol(decimalVal.toString())))
+
+        val dateVal = Date.valueOf("1998-1-2")
+        assertNull(dateIntSubject.getMapValueElement(null, ION.newSymbol(dateVal.toString())))
+        assertNull(dateIntSubject.getMapValueElement(ionNull, ION.newSymbol(dateVal.toString())))
+
+        val timestampVal = Timestamp.valueOf("2015-10-16 12:34:56.887")
+        assertNull(timestampIntSubject.getMapValueElement(null, ION.newSymbol(timestampVal.toString())))
+        assertNull(timestampIntSubject.getMapValueElement(ionNull, ION.newSymbol(timestampVal.toString())))
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun getMapValueElementForNullKey() {
-        assertNull(subject.getMapValueElement(makeStruct(), null))
+        val structs = makeStructs()
+        assertNullThrowsIllegalArgumentException(stringIntSubject, structs[0])
+        assertNullThrowsIllegalArgumentException(intIntSubject, structs[1])
+        assertNullThrowsIllegalArgumentException(bigintIntSubject, structs[2])
+        assertNullThrowsIllegalArgumentException(smallintIntSubject, structs[3])
+        assertNullThrowsIllegalArgumentException(tinyintIntSubject, structs[4])
+        assertNullThrowsIllegalArgumentException(floatIntSubject, structs[5])
+        assertNullThrowsIllegalArgumentException(doubleIntSubject, structs[6])
+        assertNullThrowsIllegalArgumentException(booleanIntSubject, structs[7])
+        assertNullThrowsIllegalArgumentException(decimalIntSubject, structs[8])
+        assertNullThrowsIllegalArgumentException(dateIntSubject, structs[9])
+        assertNullThrowsIllegalArgumentException(timestampIntSubject, structs[10])
+    }
+
+    private fun assertNullThrowsIllegalArgumentException(subject: IonStructToMapObjectInspector, struct: IonStruct) {
+        try {
+            assertNull(subject.getMapValueElement(struct, null))
+            fail("IllegalArgumentException expected")
+        } catch (e: IllegalArgumentException) {
+            // success
+        } catch (e: Exception) {
+            fail("Expected IllegalArgumentException, caught $e")
+        }
     }
 
     @Test
     fun getMap() {
-        val struct = makeStruct()
+        val structs = makeStructs()
+        testGetMaps(structs[0], stringIntSubject, testStrings)
+        testGetMaps(structs[1], intIntSubject, testInts)
+        testGetMaps(structs[1], intIntSubjectOverflow, testInts)
+        testGetMaps(structs[2], bigintIntSubject, testBigints)
+        testGetMaps(structs[3], smallintIntSubject, testSmallints)
+        testGetMaps(structs[4], tinyintIntSubject, testTinyints)
+        testGetMaps(structs[5], floatIntSubject, testFloats)
+        testGetMaps(structs[6], doubleIntSubject, testDoubles)
+        testGetMaps(structs[7], booleanIntSubject, testBooleans)
+        testGetMaps(structs[8], decimalIntSubject, testDecimals)
+        testGetMaps(structs[9], dateIntSubject, testDates)
+        testGetMaps(structs[10], timestampIntSubject, testTimestamps)
+    }
 
-        val actual = subject.getMap(struct)
-        assertEquals(3, actual.size)
-        assertEquals(ION.newInt(1), actual["a"])
-        assertEquals(ION.newInt(2), actual["b"])
-        assertEquals(ION.newInt(3), actual["c"])
+    private fun testGetMaps(struct : IonStruct, subject : IonStructToMapObjectInspector, keyValues : List<Any>) {
+        val map = subject.getMap(struct)
+        assertEquals(keyValues.size, map.size)
+        var ionVal = 1
+        keyValues.forEach{assertEquals(ION.newInt(ionVal++), map[it])}
     }
 
     @Test
     fun getMapForNullData() {
+        testGetMapForNullData(stringIntSubject)
+
+        testGetMapForNullData(intIntSubjectOverflow)
+        testGetMapForNullData(bigintIntSubject)
+        testGetMapForNullData(smallintIntSubject)
+        testGetMapForNullData(tinyintIntSubject)
+
+        testGetMapForNullData(floatIntSubject)
+        testGetMapForNullData(doubleIntSubject)
+        testGetMapForNullData(decimalIntSubject)
+
+        testGetMapForNullData(booleanIntSubject)
+
+        testGetMapForNullData(dateIntSubject)
+        testGetMapForNullData(timestampIntSubject)
+    }
+
+    private fun testGetMapForNullData(subject : IonStructToMapObjectInspector) {
         assertNull(subject.getMap(null))
         assertNull(subject.getMap(ionNull))
     }
 
     @Test
     fun getMapSize() {
-        assertEquals(3, subject.getMapSize(makeStruct()))
+        val structs = makeStructs()
+        assertEquals(3, stringIntSubject.getMapSize(structs[0]))
+        assertEquals(3, intIntSubject.getMapSize(structs[1]))
+        assertEquals(3, intIntSubjectOverflow.getMapSize(structs[1]))
+        assertEquals(3, bigintIntSubject.getMapSize(structs[2]))
+        assertEquals(3, smallintIntSubject.getMapSize(structs[3]))
+        assertEquals(3, tinyintIntSubject.getMapSize(structs[4]))
+        assertEquals(3, floatIntSubject.getMapSize(structs[5]))
+        assertEquals(3, doubleIntSubject.getMapSize(structs[6]))
+        assertEquals(2, booleanIntSubject.getMapSize(structs[7]))
+        assertEquals(2, decimalIntSubject.getMapSize(structs[8]))
+        assertEquals(2, dateIntSubject.getMapSize(structs[9]))
+        assertEquals(2, timestampIntSubject.getMapSize(structs[10]))
     }
 
     @Test
     fun getMapSizeForNull() {
+        testGetMapSizeForNull(stringIntSubject)
+
+        testGetMapSizeForNull(intIntSubjectOverflow)
+        testGetMapSizeForNull(bigintIntSubject)
+        testGetMapSizeForNull(smallintIntSubject)
+        testGetMapSizeForNull(tinyintIntSubject)
+
+        testGetMapSizeForNull(floatIntSubject)
+        testGetMapSizeForNull(doubleIntSubject)
+        testGetMapSizeForNull(decimalIntSubject)
+
+        testGetMapSizeForNull(booleanIntSubject)
+
+        testGetMapSizeForNull(dateIntSubject)
+        testGetMapSizeForNull(timestampIntSubject)
+    }
+
+    private fun testGetMapSizeForNull(subject : IonStructToMapObjectInspector) {
         assertEquals(-1, subject.getMapSize(null))
         assertEquals(-1, subject.getMapSize(ionNull))
     }
 
     @Test
     fun getTypeName() {
-        assertEquals("map<string,int>", subject.typeName)
+        assertEquals("map<string,int>", stringIntSubject.typeName)
+        assertEquals("map<int,int>", intIntSubject.typeName)
+        assertEquals("map<bigint,int>", bigintIntSubject.typeName)
+        assertEquals("map<smallint,int>", smallintIntSubject.typeName)
+        assertEquals("map<tinyint,int>", tinyintIntSubject.typeName)
+        assertEquals("map<float,int>", floatIntSubject.typeName)
+        assertEquals("map<double,int>", doubleIntSubject.typeName)
+        assertEquals("map<boolean,int>", booleanIntSubject.typeName)
+        assertEquals("map<decimal(38,18),int>", decimalIntSubject.typeName)
+        assertEquals("map<date,int>", dateIntSubject.typeName)
+        assertEquals("map<timestamp,int>", timestampIntSubject.typeName)
     }
 
     @Test
     fun getCategory() {
-        assertEquals(MAP, subject.category)
+        assertEquals(MAP, stringIntSubject.category)
+        assertEquals(MAP, intIntSubject.category)
+        assertEquals(MAP, bigintIntSubject.category)
+        assertEquals(MAP, smallintIntSubject.category)
+        assertEquals(MAP, tinyintIntSubject.category)
+        assertEquals(MAP, floatIntSubject.category)
+        assertEquals(MAP, doubleIntSubject.category)
+        assertEquals(MAP, booleanIntSubject.category)
+        assertEquals(MAP, decimalIntSubject.category)
+        assertEquals(MAP, dateIntSubject.category)
+        assertEquals(MAP, timestampIntSubject.category)
     }
 
-    private fun makeStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
+    private fun makeStructs(): List<IonStruct> {
+        return listOf<IonStruct>(
+                generateStruct(testStrings),
+                generateStruct(testInts.map { it.toString() }),
+                generateStruct(testBigints.map { it.toString() }),
+                generateStruct(testSmallints.map { it.toString() }),
+                generateStruct(testTinyints.map { it.toString() }),
+                generateStruct(testFloats.map { it.toString() }),
+                generateStruct(testDoubles.map { it.toString() }),
+                generateStruct(testBooleans.map { it.toString() }),
+                generateStruct(testDecimals.map { it.toString() }),
+                generateStruct(testDates.map { it.toString() }),
+                generateStruct(testTimestamps.map { getTsKey(it) }))
+    }
 
-        struct.add("a", ION.newInt(1))
-        struct.add("b", ION.newInt(2))
-        struct.add("c", ION.newInt(3))
+    private fun getTsKey(timestamp: Timestamp): String {
+        return com.amazon.ion.Timestamp.forSqlTimestampZ(timestamp).toString()
+    }
 
+    private fun generateStruct(keys : List<String>): IonStruct {
+        val struct = ION.newEmptyStruct();
+        var structVal = 1
+        keys.stream().forEach{struct.add(it, ION.newInt(structVal++))}
         return struct
     }
 


### PR DESCRIPTION
This PR allows for all hive primitive types to be used as keys in Hive maps. Since Ion requires that all keys be symbols, we first convert the hive primitive to a string, that can then be included as a symbol when serialized to Ion. During deserialization, the object inspectors will read the field name and parse the Hive/java primitive object from the string.

Use Case and Example:

The serde serializes Hive maps as Ion structs, using the key values as struct keys.
```
MAP<STRING, STRING>
["a", "b", "c"]
["value1", "value2", "value3"]
```

Gets serialized in Ion as 
`{'a':"value1", 'b':"value2", 'c':"value3"}`

Hive maps can use any primitive type as a key value for its map type. Since Ion struct keys are symbols, this issue manifests itself when the Hive primitive used as a key is not a type that is natively converted to IonText, like if the schema has a MAP<INT, STR>. If such a schema is passed in currently, the serde will throw an error during the write. While this is not an issue if the data is externally generated in Ion natively and just being read via the serde, it does limit the generation of new data, whether it is being inserted as a value or being copied from an existing table (stored in another format).

With this PR, instead of an error being thrown, the data will first be converted to a string before being converted to a symbol.
For example:

```
MAP<INT, STR>
[1, 2, 3]
["value1", "value2", "value3"]
```

will now get serialized as 

```
{'1':"value1", '2':"value2", '3':"value3"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
