### PR TITLE
Reduce build matrix to LTS JDKs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 9, 10, 11]
+        java: [8, 11]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
*Issue #, if available:* #104 

*Description of changes:* 
The project build against JDK 10 failed with the following message:
```plain
* What went wrong:
Execution failed for task ':serde:compileJava'.
> java.lang.reflect.UndeclaredThrowableException
```

I have not reproduced this failure locally for JDKs 8 or 11, and JDK 10 is non-LTS and has been unsupported by anyone for more than 4 years now. There's no reason for us to waste time or energy working with non-LTS JDKs.

Compare to e.g. the build workflow for [ion-java](https://github.com/amazon-ion/ion-java/blob/master/.github/workflows/main.yml#L14-L18) where we only build against JDKs 8 and 11. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
