### PR TITLE
Update urls to use the new org name: amzn:amazon-ion.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/amzn/amazon-ion-hive-serde/issues), or [recently closed](https://github.com/amzn/amazon-ion-hive-serde/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
+When filing an issue, please check [existing open](https://github.com/amazon-ion/ion-hive-serde/issues), or [recently closed](https://github.com/amazon-ion/ion-hive-serde/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
@@ -41,7 +41,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/amzn/amazon-ion-hive-serde/labels/help%20wanted) issues is a great place to start. 
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/amazon-ion/ion-hive-serde/labels/help%20wanted) issues is a great place to start. 
 
 
 ## Code of Conduct
@@ -56,6 +56,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/amzn/amazon-ion-hive-serde/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/amazon-ion/ion-hive-serde/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ A Apache Hive SerDe (short for serializer/deserializer) for the Ion file format.
 * Read data stored in Ion format both binary and text.
 * Supports all Ion types including nested data structures, see [Type mapping documentation](docs/type-mapping.md)
 for more information.
-* Supports flattening of Ion documents through [path extraction](https://github.com/amzn/ion-java-path-extraction).
+* Supports flattening of Ion documents through [path extraction](https://github.com/amazon-ion/ion-java-path-extraction).
 * Supports importing shared symbol tables and custom symbol table catalogs.
 * `IonInputFormat` and `IonOutputFormat` are able to handle both Ion binary and Ion text.
 * Configurable through [SerDe properties](docs/serde-properties.md).
 
 ### Installation
-Download the latest `ion-hive-serde-all-<version-number>.jar` from [https://github.com/amzn/ion-hive-serde/releases]
+Download the latest `ion-hive-serde-all-<version-number>.jar` from [https://github.com/amazon-ion/ion-hive-serde/releases]
 and place the JARs into `hive/lib` or use `ADD JAR` in Hive. That jar contains the SerDe and all its dependencies.
 
 To build it locally run :`./gradlew :serde:singleJar`

--- a/docs/serde-properties.md
+++ b/docs/serde-properties.md
@@ -26,7 +26,7 @@ WITH SERDEPROPERTIES (
 ```
 
 `OFFSET` is represented as `<signal>hh:mm`, examples: `01:00`, `+01:00`, `-09:30`, `Z` (UTC, same
-as `00:00`), see [timestamp](http://amzn.github.io/ion-docs/docs/spec.html#timestamp) specification
+as `00:00`), see [timestamp](https://amazon-ion.github.io/ion-docs/docs/spec.html#timestamp) specification
 for more details.
 
 ## Serialize null columns
@@ -159,7 +159,7 @@ SELECT c1, c2 FROM myTable;
 ```
 
 ## Path extractor
-[Path extraction](https://github.com/amzn/ion-java-path-extraction) can be used to map between ion values and hive 
+[Path extraction](https://github.com/amazon-ion/ion-java-path-extraction) can be used to map between ion values and hive 
 columns. 
 
 Specification: 
@@ -350,10 +350,10 @@ Hive table
 
 ## Catalog
 Catalogs can be used by the SerDe to find any imported 
-[shared symbol tables](http://amzn.github.io/ion-docs/docs/symbols.html#shared-symbol-tables).
+[shared symbol tables](https://amazon-ion.github.io/ion-docs/docs/symbols.html#shared-symbol-tables).
 
 Catalogs can be defined in one of three ways, in order or priority: 
-1. Class: implementation of [IonCatalog](https://github.com/amzn/ion-java/blob/master/src/com/amazon/ion/IonCatalog.java).
+1. Class: implementation of [IonCatalog](https://github.com/amazon-ion/ion-java/blob/master/src/com/amazon/ion/IonCatalog.java).
 Must be added as a jar to hive in the same way the SerDe jar is included 
 1. Local File: shared symbol tables declared in a local file  
 1. URL: shared symbol tables resource URL 

--- a/docs/type-mapping.md
+++ b/docs/type-mapping.md
@@ -1,6 +1,6 @@
 # Type mapping
 [Hive type system](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types) and the
-[Ion type system](http://amzn.github.io/ion-docs/docs/spec.html) don't always map one to one so
+[Ion type system](https://amazon-ion.github.io/ion-docs/docs/spec.html) don't always map one to one so
 some conversions must be made. For those [SerDe properties](serde-properties.md) can be used for fine tuning.
 
  **Type mapping from Ion types to Hive types during deserialization:**

--- a/integration-test/src/test/kotlin/com/amazon/ionhiveserde/integrationtest/docker/HDFS.kt
+++ b/integration-test/src/test/kotlin/com/amazon/ionhiveserde/integrationtest/docker/HDFS.kt
@@ -21,7 +21,7 @@ package com.amazon.ionhiveserde.integrationtest.docker
  * There is something wrong with the hadoop docker config that's blocking interacting with HDFS from outside the docker
  * container. To work around that we are using shell to send commands to docker to manipulate HDFS.
  *
- * See https://github.com/amzn/ion-hive-serde/issues/37 for more info
+ * See https://github.com/amazon-ion/ion-hive-serde/issues/37 for more info
  */
 object HDFS {
 

--- a/serde/build.gradle
+++ b/serde/build.gradle
@@ -58,12 +58,12 @@ publishing {
             pom {
                 name = "Ion Hive SerDe"
                 packaging = "jar"
-                url = "https://github.com/amzn/ion-hive-serde"
+                url = "https://github.com/amazon-ion/ion-hive-serde"
                 description = "A Apache Hive SerDe (short for serializer/deserializer) for the Ion file format."
                 scm {
-                    connection = "scm:git@github.com:amzn/ion-hive-serde.git"
-                    developerConnection = "scm:git@github.com:amzn/ion-hive-serde.git"
-                    url = "git@github.com:amzn/ion-hive-serde.git"
+                    connection = "scm:git@github.com:amazon-ion/ion-hive-serde.git"
+                    developerConnection = "scm:git@github.com:amazon-ion/ion-hive-serde.git"
+                    url = "git@github.com:amazon-ion/ion-hive-serde.git"
                 }
 
                 licenses {
@@ -78,7 +78,7 @@ publishing {
                         name = "Amazon Ion Team"
                         email = "ion-team@amazon.com"
                         organization = "Amazon Labs"
-                        organizationUrl = "https://github.com/amzn"
+                        organizationUrl = "https://github.com/amazon-ion"
                     }
                 }
             }

--- a/serde/src/main/java/com/amazon/ionhiveserde/IonHiveSerDe.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/IonHiveSerDe.java
@@ -52,7 +52,7 @@ import org.apache.hadoop.io.Writable;
 
 /**
  * <p>
- * Hive SerDe for the <a href="https://amzn.github.io/ion-docs/docs.html">Amazon Ion</a> data format.
+ * Hive SerDe for the <a href="https://amazon-ion.github.io/ion-docs/docs.html">Amazon Ion</a> data format.
  * </p>
  * <p>
  * For more information on Hive SerDes see <a href="https://cwiki.apache.org/confluence/display/Hive/SerDe">wiki</a>.
@@ -142,7 +142,7 @@ public class IonHiveSerDe extends AbstractSerDe {
                 1. We need a key-value store to carry column values
                 2. The top-level IonStruct as a context object carries the IonSystem which we use as a ValueFactory in
                    the callbacks created in PathExtractionConfig
-                Refer to https://github.com/amzn/ion-hive-serde/issues/61.
+                Refer to https://github.com/amazon-ion/ion-hive-serde/issues/61.
             */
             IonStruct struct = domFactory.newEmptyStruct();
             if (!serDeProperties.pathExtractorCaseSensitivity()) {

--- a/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonStructCaseInsensitiveDecorator.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonStructCaseInsensitiveDecorator.java
@@ -92,7 +92,7 @@ public class IonStructCaseInsensitiveDecorator extends IonContainerCaseInsensiti
        Argument `fieldName` is case sensitive so below method removes the desired value, which means it's possible that
        struct.containsKey(fieldName) returns true while struct.remove(fieldName) does nothing.
 
-       Refer to https://github.com/amzn/ion-hive-serde/issues/60.
+       Refer to https://github.com/amazon-ion/ion-hive-serde/issues/60.
      */
     public IonValue remove(final String fieldName) {
         return IonCaseInsensitiveDecorator.wrapValue(ionStruct.remove(fieldName));

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonLobToBinaryObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonLobToBinaryObjectInspectorTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.assertTrue
 class IonLobToBinaryObjectInspectorTest
     : AbstractIonPrimitiveJavaObjectInspectorTest<IonLob, BytesWritable, ByteArray>() {
 
-    // CLOBs are encoded as 7 bit ASCII, see http://amzn.github.io/ion-docs/docs/spec.html#clob
+    // CLOBs are encoded as 7 bit ASCII, see https://amazon-ion.github.io/ion-docs/docs/spec.html#clob
     private val raw = "12345678".toByteArray(charset = Charsets.US_ASCII)
 
     override val subject = com.amazon.ionhiveserde.objectinspectors.IonLobToBinaryObjectInspector()


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR updated the urls to use new org name: amzn --> amazon-ion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
